### PR TITLE
feat: support for scheduled triggers

### DIFF
--- a/dags/generate_dags.py
+++ b/dags/generate_dags.py
@@ -25,7 +25,8 @@ def generate_dags():
         result = client.get_object(Bucket=bucket, Key=key)
         collection = result["Body"].read().decode()
         collection = json.loads(collection)
-        get_discover_dag(id=collection["id"], event=collection)
+        if collection.get("schedule"):
+            get_discover_dag(id=collection["id"], event=collection)
         
 
 generate_dags()

--- a/dags/generate_dags.py
+++ b/dags/generate_dags.py
@@ -1,0 +1,31 @@
+"""
+Builds a DAG for each collection (indicated by a .json file) in the <BUCKET>/collections/ folder.
+These DAGs are used to discover and ingest items for each collection.
+"""
+from airflow.models.variable import Variable
+
+
+from veda_data_pipeline.veda_discover_pipeline import get_discover_dag
+
+
+def generate_dags():
+    import boto3
+    import json
+
+    MWAA_STAC_CONF = Variable.get("MWAA_STACK_CONF", deserialize_json=True)
+    bucket = MWAA_STAC_CONF["EVENT_BUCKET"]
+
+    client = boto3.client('s3')
+    response = client.list_objects_v2(Bucket=bucket, Prefix="collections/")
+
+    for file_ in response["Contents"]:
+        key = file_["Key"]
+        if key.endswith("/"):
+            continue
+        result = client.get_object(Bucket=bucket, Key=key)
+        collection = result["Body"].read().decode()
+        collection = json.loads(collection)
+        get_discover_dag(id=collection["id"], event=collection)
+        
+
+generate_dags()

--- a/dags/veda_data_pipeline/groups/discover_group.py
+++ b/dags/veda_data_pipeline/groups/discover_group.py
@@ -13,11 +13,17 @@ from veda_data_pipeline.utils.s3_discovery import (
 group_kwgs = {"group_id": "Discover", "tooltip": "Discover"}
 
 
-def discover_from_s3_task(ti):
+def discover_from_s3_task(ti, event={}, **kwargs):
     """Discover grouped assets/files from S3 in batches of 2800. Produce a list of such files stored on S3 to process.
     This task is used as part of the discover_group subdag and outputs data to EVENT_BUCKET.
     """
-    config = ti.dag_run.conf
+    config = {
+        **event,
+        **ti.dag_run.conf,
+    }
+    if not kwargs.get('dag_run').external_trigger:
+        config["last_successful_execution"] = kwargs.get("prev_start_date_success")
+
     # (event, chunk_size=2800, role_arn=None, bucket_output=None):
     MWAA_STAC_CONF = Variable.get("MWAA_STACK_CONF", deserialize_json=True)
     read_assume_arn = Variable.get("ASSUME_ROLE_READ_ARN", default_var=None)
@@ -53,12 +59,13 @@ def vector_raster_choice(ti):
     return f"{group_kwgs['group_id']}.parallel_run_process_rasters"
 
 
-def subdag_discover():
+def subdag_discover(event):
     with TaskGroup(**group_kwgs) as discover_grp:
         discover_from_s3 = PythonOperator(
             task_id="discover_from_s3",
             python_callable=discover_from_s3_task,
-            op_kwargs={"text": "Discover from S3"},
+            op_kwargs={"text": "Discover from S3", "event": event},
+            provide_context=True,
         )
 
         raster_vector_branching = BranchPythonOperator(


### PR DESCRIPTION
**Summary:** Support for scheduled ingests

Addresses https://github.com/US-GHG-Center/ghgc-architecture/issues/122

## Changes
* a new `generate_dags.py` file that generates a separate dag for each collection that has a schedule - so that we can run the ingests based on different schedules
* updated the s3 discovery such that if it is run on a schedule, it'll only grab files that have been updated since the last successful run
